### PR TITLE
Add Simplified Chinese (zh_CN) translation

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -9,3 +9,4 @@ it
 nb
 ru
 tr
+zh_CN

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,0 +1,97 @@
+# Chinese (China) translation for hieroglyphic.
+# Copyright (C) 2024 hieroglyphic's COPYRIGHT HOLDER
+# This file is distributed under the same license as the hieroglyphic package.
+# lumingzh <lumingzh@qq.com>, 2024.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: hieroglyphic main\n"
+"Report-Msgid-Bugs-To: https://github.com/FineFindus/Hieroglyphic/issues\n"
+"POT-Creation-Date: 2024-09-17 19:26+0000\n"
+"PO-Revision-Date: 2024-09-18 09:37+0800\n"
+"Last-Translator: lumingzh <lumingzh@qq.com>\n"
+"Language-Team: Chinese (China) <i18n-zh@googlegroups.com>\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Gtranslator 46.1\n"
+
+#: data/io.github.finefindus.Hieroglyphic.desktop.in.in:3
+#: data/io.github.finefindus.Hieroglyphic.metainfo.xml.in.in:8 src/about.rs:20
+#: src/main.rs:25
+msgid "Hieroglyphic"
+msgstr "Hieroglyphic"
+
+#: data/io.github.finefindus.Hieroglyphic.desktop.in.in:4
+msgid "Search through over 1000 different LaTeX symbols by sketching"
+msgstr "通过草图搜索 1000 多种不同的 LaTeX 符号"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: data/io.github.finefindus.Hieroglyphic.desktop.in.in:10
+msgid "GTK;Tools;LaTeX;TeX;Symbols;"
+msgstr "GTK;Tools;LaTeX;TeX;Symbols;工具;符号;"
+
+#: data/io.github.finefindus.Hieroglyphic.gschema.xml.in:6
+msgid "Whether to show a small nudge towards the contribution dialog"
+msgstr "是否显示指向贡献对话框的小提示"
+
+#: data/io.github.finefindus.Hieroglyphic.gschema.xml.in:10
+msgid "Whether to contribute recognized strokes"
+msgstr "是否贡献已识别的笔画"
+
+#: data/io.github.finefindus.Hieroglyphic.metainfo.xml.in.in:9
+msgid "Find LaTeX symbols"
+msgstr "查找 LaTeX 符号"
+
+#: data/io.github.finefindus.Hieroglyphic.metainfo.xml.in.in:18
+msgid ""
+"If you work with LaTeX, you know it's difficult to memorize the names of all "
+"the symbols. Hieroglyphic allows you to search through over 1000 different "
+"LaTeX symbols by sketching."
+msgstr ""
+"如果您使用 LaTeX 则应知道记忆所有符号的名称非常困难。Hieroglyphic 可让您通过"
+"画草图来搜索 1000 多种不同的 LaTeX 符号。"
+
+#: data/io.github.finefindus.Hieroglyphic.metainfo.xml.in.in:24
+msgid "Main Window"
+msgstr "主窗口"
+
+#: data/io.github.finefindus.Hieroglyphic.metainfo.xml.in.in:28
+msgid "Placeholder"
+msgstr "占位符"
+
+#: data/resources/ui/contribution-dialog.ui:31 data/resources/ui/window.ui:24
+msgid "Improve Hieroglyphic"
+msgstr "提升 Hieroglyphic"
+
+#: data/resources/ui/contribution-dialog.ui:32
+msgid ""
+"Help improve Hieroglyphic by automatically contributing recognized symbols"
+msgstr "通过自动贡献已识别的符号来帮助提升 Hieroglyphic"
+
+#: data/resources/ui/window.ui:36
+msgid "About Hieroglyphic"
+msgstr "关于 Hieroglyphic"
+
+#: data/resources/ui/window.ui:50
+msgid "No Symbols"
+msgstr "无符号"
+
+#: data/resources/ui/window.ui:51
+msgid "Start by drawing a symbol"
+msgstr "开始绘制符号"
+
+#: data/resources/ui/window.ui:118
+msgid "_Clear"
+msgstr "清除(_C)"
+
+#. Translators: This should not be translate, Please enter your credits here instead (format: "Name https://example.com" or "Name <email@example.com>", no quotes)
+#: src/about.rs:26
+msgid "translator-credits"
+msgstr "lumingzh <lumingzh@qq.com>, 2024."
+
+#: src/window.rs:378
+msgid "Copied “{}”"
+msgstr "已复制“{}”"


### PR DESCRIPTION
This pull request initiate the Simplified Chinese (`zh_CN`) translation for Hieroglyphic. As the `zh_CN` translation is being added for the first time, it has to be merged into the git repo first (i.e. via GitHub Pull Requests) before being able to be handled by l10n.gnome.org automatically.

The translation file is taken from https://l10n.gnome.org/vertimus/hieroglyphic/main/po/zh_CN/ , and the content has been approved by the l10n.gnome.org Simplified Chinese translation coordinator.

Please let me know if you have any comments or questions.