### PR TITLE
Add D-Bus service file

### DIFF
--- a/data/io.github.finefindus.Hieroglyphic.desktop.in.in
+++ b/data/io.github.finefindus.Hieroglyphic.desktop.in.in
@@ -10,3 +10,4 @@ Keywords=GTK;Tools;LaTeX;TeX;Symbols;
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=@icon@
 StartupNotify=true
+DBusActivatable=true

--- a/data/io.github.finefindus.Hieroglyphic.service.in
+++ b/data/io.github.finefindus.Hieroglyphic.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=@app-id@
+Exec=@bindir@/hieroglyphic --gapplication-service

--- a/data/meson.build
+++ b/data/meson.build
@@ -74,3 +74,15 @@ if glib_compile_schemas.found()
     ],
   )
 endif
+
+# D-Bus service file
+service_conf = configuration_data()
+service_conf.set('app-id', application_id)
+service_conf.set('bindir', bindir)
+configure_file(
+  input: '@0@.service.in'.format(base_id),
+  output: '@0@.service'.format(application_id),
+  configuration: service_conf,
+  install: true,
+  install_dir: datadir / 'dbus-1' / 'services'
+)


### PR DESCRIPTION
And mark the application as D-Bus activatable. This allows application launchers to activate it via D-Bus.

Reference:
https://specifications.freedesktop.org/desktop-entry-spec/1.3/dbus.html