### PR TITLE
metainfo: Mark as mobile-friendly, add categories

### DIFF
--- a/data/io.github.finefindus.Hieroglyphic.metainfo.xml.in.in
+++ b/data/io.github.finefindus.Hieroglyphic.metainfo.xml.in.in
@@ -124,7 +124,7 @@
   </recommends>
 
   <requires>
-    <display_length compare="ge">370</display_length>
+    <display_length compare="ge">360</display_length>
   </requires>
 
   <custom>

--- a/data/io.github.finefindus.Hieroglyphic.metainfo.xml.in.in
+++ b/data/io.github.finefindus.Hieroglyphic.metainfo.xml.in.in
@@ -18,6 +18,12 @@
     <p>If you work with LaTeX, you know it's difficult to memorize the names of all the symbols. Hieroglyphic allows you to search through over 1000 different LaTeX symbols by sketching.</p>
   </description>
 
+  <categories>
+    <category>Math</category>
+    <category>Science</category>
+    <category>Utility</category>
+  </categories>
+
   <screenshots>
     <screenshot type="default">
         <image>https://raw.githubusercontent.com/FineFindus/Hieroglyphic/main/data/resources/screenshots/window.png</image>


### PR DESCRIPTION
Hi, 
thank you for creating this amazing app and making it mobile-friendly!

This PR changes two things:
- it marks it as adaptive for phones (360 is the magic value for [flathub](https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#display-size) and on [devices](https://linuxphoneapps.org/docs/resources/developer-information/#hardware-specs-to-consider)
- it adds [valid categories](https://specifications.freedesktop.org/menu-spec/latest/additional-category-registry.html) based on https://github.com/FineFindus/Hieroglyphic/blob/66d194bfa282e73c27c37b76a5424242146f8aa9/data/io.github.finefindus.Hieroglyphic.desktop.in.in#L7C1-L7C43  (I think Education could be added, too, but that's up to you!)

It will also make the app show up in [Flathub's Mobile Collection](https://flathub.org/en/apps/collection/mobile/1).

Cheers,
Peter