### PR TITLE
metainfo: use translate="no" for developer name

### DIFF
--- a/data/io.github.finefindus.Hieroglyphic.metainfo.xml.in.in
+++ b/data/io.github.finefindus.Hieroglyphic.metainfo.xml.in.in
@@ -8,9 +8,9 @@
   <name>Hieroglyphic</name>
   <summary>Find LaTeX and Typst symbols</summary>
   <!-- developer_name tag deprecated with Appstream 1.0 -->
-  <developer_name translatable="no">FineFindus</developer_name>
+  <developer_name translate="no">FineFindus</developer_name>
   <developer id="io.github.finefindus">
-      <name translatable="no">FineFindus</name>
+      <name translate="no">FineFindus</name>
   </developer>
   <update_contact>finefindus@proton.me</update_contact>
 


### PR DESCRIPTION
GNOME's translation platform at l10n.gnome.org recently fixed its ITS file usage, it now follows rules from https://github.com/ximion/appstream/blob/main/data/its/metainfo.its, expecting `translate="no"` for metainfo files. Also mentioned in the [Appstream docs](https://distributions.freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html).

Using translatable="no" as in [io.github.finefindus.Hieroglyphic.metainfo.xml.in.in](https://github.com/FineFindus/Hieroglyphic/blob/main/data/io.github.finefindus.Hieroglyphic.metainfo.xml.in.in#L11) doesn't work. Can be seen in recent commits like 02b3e386aad0f2c206a24f9796743bd12108cbb2 where the string is translated.
